### PR TITLE
Fix L07intro2.lean conclusion

### DIFF
--- a/Game/Levels/Implication/L07intro2.lean
+++ b/Game/Levels/Implication/L07intro2.lean
@@ -26,8 +26,8 @@ Statement (x : ℕ) : x + 1 = y + 1 → x = y := by
 Conclusion "Here's a completely backwards proof:
 ```
 intro h
-repeat rw [succ_eq_add_one]
 apply succ_inj
+repeat rw [succ_eq_add_one]
 exact h
 ```
 "


### PR DESCRIPTION
While the proof works (`repeat` rewrites 0 times and `exact` closes `succ x` with `x + 1` directly), the intended proof should have lines 2 and 3 swapped.