### PR TITLE
"Leave World" button is now called "Home"

### DIFF
--- a/Game/Levels/Tutorial/L08twoaddtwo.lean
+++ b/Game/Levels/Tutorial/L08twoaddtwo.lean
@@ -54,7 +54,7 @@ around to investigate. When you've finished, click the `>_` button in the top ri
 move back into \"Typewriter mode\".
 
 You have finished tutorial world!
-Click \"Leave World\" to go back to the
+Click \"Home\" to go back to the
 overworld, and select Addition World, where you will learn
 about the `induction` tactic.
 "


### PR DESCRIPTION
It seems that the name of the "Home" button changed from "Leave World" to "Home" in lean4game, but the instructions here did not reflect this change.