### PR TITLE
docs: document simp only variant in simp TacticDoc

### DIFF
--- a/Game/Levels/Algorithm/L03add_algo2.lean
+++ b/Game/Levels/Algorithm/L03add_algo2.lean
@@ -15,6 +15,15 @@ Lean's simplifier, `simp`, will rewrite every lemma
 tagged with `simp` and every lemma fed to it by the user, as much as it can.
 Furthermore, it will attempt to order variables into an internal order if fed
 lemmas such as `add_comm`, so that it does not go into an infinite loop.
+
+## Variants
+
+* `simp only [h₁, h₂, ...]` restricts the simplifier to *only* the named
+  lemmas `h₁, h₂, ...` and ignores the global `@[simp]` lemma set, giving
+  a smaller and more predictable rewrite step. The same internal ordering
+  for permutation lemmas (such as `add_comm`) still applies, so feeding
+  symmetric lemmas does not loop. This level is solved by
+  `simp only [add_left_comm, add_comm]`.
 -/
 TacticDoc simp
 


### PR DESCRIPTION
## What

Extends the `TacticDoc simp` block in `Game/Levels/Algorithm/L03add_algo2.lean` with a `## Variants` subsection that documents `simp only [h₁, h₂, ...]`. No level statements, no tactic behaviour, no other docs touched.

## Why

Closes #72. Algorithm world level 3 hints and solves with `simp only [add_left_comm, add_comm]`, but the in-game `simp` doc previously described only the bare `simp` tactic. Players see `simp only` for the first time without any explanation of what `only` does.

## How

Doc-only edit inside the `/-- ... -/` docstring immediately above `TacticDoc simp`.

### Why this location (codebase convention)

- Every live `TacticDoc` in NNG4 is co-located with the level that first introduces it, e.g. `simp` at `Algorithm/L03add_algo2.lean`, `simp_add` at `Algorithm/L04add_algo3.lean`, `rw` at `Tutorial/L02rw.lean`, `induction` at `Addition/L01zero_add.lean` (24 total, all the same pattern).
- `Game/Doc/Tactics.lean` is **not** the home of TacticDocs — every entry there is commented out with `--` and unused. The live docs are in the level files.
- Variants/modifiers of a tactic are documented as a `Variants` subsection of the same `TacticDoc`, not as a separate doc. Precedent: `TacticDoc rw` in `Tutorial/L02rw.lean` lists `rw [← h]` / `rw [h] at h2` / `rw [h] at *` under `### Variants`. `simp only` is a modifier of `simp`, so it belongs under `TacticDoc simp` the same way.

### Why this content is correct

Verified against the upstream Lean 4 source at the toolchain NNG4 pins (`leanprover/lean4:v4.23.0` per `lean-toolchain`):

- **`simp only` ignores the `@[simp]` set** — standard semantics.
- **The "internal ordering" claim from the parent docstring also applies to `simp only`.** This is implemented at the *theorem* level, not the tactic level:
  - [`src/Lean/Meta/Tactic/Simp/SimpTheorems.lean`](https://github.com/leanprover/lean4/blob/v4.23.0/src/Lean/Meta/Tactic/Simp/SimpTheorems.lean) defines `SimpTheorem.perm : Bool` — *"true if lhs and rhs are identical modulo permutation of variables"* — and sets it via `isPerm lhs rhs` when any simp theorem (global or user-supplied) is registered.
  - [`src/Lean/Meta/Tactic/Simp/Rewrite.lean`](https://github.com/leanprover/lean4/blob/v4.23.0/src/Lean/Meta/Tactic/Simp/Rewrite.lean) gates the actual rewrite on `if thm.perm then ... if !(← acLt rhs e .reduceSimpleOnly) then ... return none` — i.e., a permutation lemma like `add_comm` is only applied when the new term is strictly smaller in Lean's AC-ordering. This is what makes `simp only [add_comm]` (and `simp only [add_left_comm, add_comm]`) terminate instead of looping.
  - Because both the `perm` flag and the `acLt` check live below the tactic-vs-theorem distinction, they apply equally to `simp` and `simp only`. `rg` over the NNG4 sources finds zero `set_option simp.*` overrides, so the upstream behaviour applies unchanged here.
- **Concrete example claim**: that this level is solved by `simp only [add_left_comm, add_comm]` is the literal proof on lines 36–37 of the same file (`Hint` text + tactic).

### Style choices

- Used `## Variants` (matching `TacticDoc rw`'s `### Variants` precedent), not `## simp only`, so future variants (`simp_arith`, `simp at h`, `simp [...] at *`, …) can be added as further bullets if maintainers want.
- Did not add a separate `NewTactic simp_only` — the repo doesn't register modifiers as tactics, and `simp only` would not appear as its own sidebar entry in NNG4's UI anyway.

## Verification

- **Local build, full project: ✅** — installed `elan`, fetched the pinned `leanprover/lean4:v4.23.0`, ran `lake update` + `lake build` from a clean state. All 286 jobs built successfully (exit 0). The edited file compiled clean at job 218: `✓ Built Game.Levels.Algorithm.L03add_algo2 (7.2s)`. No new errors or warnings on the touched file.
- The only build noise observed is pre-existing and upstream — a `letFun?` deprecation in `GameServer/Tactic/LetIntros.lean` and a `Missing Tactic Documentation: contrapose!` info on `L07succ_ne_succ.lean`. Neither is related to this change.
- `.i18n/en/Game.pot` regeneration is the build's normal behaviour and is **not** committed in this PR.
- Manually inspected the rendered docstring and diff against the existing `TacticDoc rw` style — matches.
- Happy to iterate on wording or split off an Introduction-text update separately if you'd prefer `simp only` mentioned inline in the level intro as well.